### PR TITLE
Ensure get magic is called

### DIFF
--- a/ConstantTime.xs
+++ b/ConstantTime.xs
@@ -34,6 +34,9 @@ equals(a, b)
         unsigned char *bp;
         int r;
 
+        SvGETMAGIC(a);
+        SvGETMAGIC(b);
+
         if (SvOK(a) && SvOK(b)) {
           alen = SvCUR(a);
           ap = SvPV(a, alen);

--- a/t/magic.t
+++ b/t/magic.t
@@ -1,0 +1,8 @@
+use String::Compare::ConstantTime qw/equals/;
+
+use strict;
+
+use Test::More tests => 2;
+
+ok equals substr( "asdfg", 0, 4 ), "asdf";
+ok equals "asdf", substr( "asdfg", 0, 4 );


### PR DESCRIPTION
Without this change the attached test would fail on my local perls, it might vary by Perl version.

This should also fix things like tied hashes I'd imagine.