### PR TITLE
Add initial Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required
+
+language: perl
+
+perl:
+    - "5.26"
+    - "5.24"
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+
+install:
+    - cpanm --installdeps .
+
+script:
+    - RELEASE_TESTING=1 AUTHOR_TESTING=1 make test


### PR DESCRIPTION
[Travis-CI](https://travis-ci.org) is a free continuous integration service for Open Source projects to build and test their software.  This pull request adds a bare-bones configuration file for Travis-CI which successfully builds and tests String::Compare::ConstantTime on Perls 5.10 .. 5.26.

This pull request is submitted in the hope that it is useful.  If you have any questions or comments, please don't hesitate to contact me and I can update and resubmit the PR as necessary.