### PR TITLE
Add warnings pragma

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,5 @@
 use strict;
+use warnings;
 
 use ExtUtils::MakeMaker;
 

--- a/lib/String/Compare/ConstantTime.pm
+++ b/lib/String/Compare/ConstantTime.pm
@@ -1,6 +1,7 @@
 package String::Compare::ConstantTime;
 
 use strict;
+use warnings;
 
 our $VERSION = '0.312';
 

--- a/t/accuracy.t
+++ b/t/accuracy.t
@@ -1,6 +1,7 @@
-use String::Compare::ConstantTime qw/equals/;
-
 use strict;
+use warnings;
+
+use String::Compare::ConstantTime qw/equals/;
 
 use utf8;
 

--- a/t/magic.t
+++ b/t/magic.t
@@ -1,6 +1,7 @@
-use String::Compare::ConstantTime qw/equals/;
-
 use strict;
+use warnings;
+
+use String::Compare::ConstantTime qw/equals/;
 
 use Test::More tests => 2;
 


### PR DESCRIPTION
This change adds the warnings pragma to all files which did not have it.  Using the warnings pragma is considered current best practice, allows the code to almost pass `Perl::Critic` at severity level 4, and solves the `use_warnings` [CPANTS](https://cpants.cpanauthors.org/dist/String-Compare-ConstantTime) issue.

This PR is submitted in the hope that it is useful.  If you have any questions or comments, please don't hesitate to contact me and I can update and resubmit the PR as necessary.