### PR TITLE
Update Makefile.PL metadata

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,6 +5,7 @@ use ExtUtils::MakeMaker;
 
 my %args = (
     NAME              => 'String::Compare::ConstantTime',
+    AUTHOR            => ['Doug Hoyte <doug@hcsw.org>'],
     VERSION_FROM      => 'lib/String/Compare/ConstantTime.pm',
     PREREQ_PM         => {
                          },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,8 +17,7 @@ my %args = (
     },
 );
 
-my $eummv = eval ($ExtUtils::MakeMaker::VERSION);
-if ($eummv >= 6.45) {
+if ($ExtUtils::MakeMaker::VERSION >= 6.45) {
     $args{META_MERGE} = {
         resources => {
             repository => 'git://github.com/hoytech/String-Compare-ConstantTime.git',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,6 +6,7 @@ use ExtUtils::MakeMaker;
 my %args = (
     NAME              => 'String::Compare::ConstantTime',
     AUTHOR            => ['Doug Hoyte <doug@hcsw.org>'],
+    ABSTRACT_FROM     => 'lib/String/Compare/ConstantTime.pm',
     VERSION_FROM      => 'lib/String/Compare/ConstantTime.pm',
     PREREQ_PM         => {
                          },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,13 +17,14 @@ my %args = (
     },
 );
 
-if ($ExtUtils::MakeMaker::VERSION >= 6.45) {
+if ($ExtUtils::MakeMaker::VERSION >= 6.48) {
     $args{META_MERGE} = {
         resources => {
             repository => 'git://github.com/hoytech/String-Compare-ConstantTime.git',
             bugtracker => 'https://github.com/hoytech/String-Compare-ConstantTime/issues',
         },
     };
+    $args{MIN_PERL_VERSION} = 5.8.0;
 }
 
 WriteMakefile(%args);

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,9 +8,6 @@ my %args = (
     VERSION_FROM      => 'lib/String/Compare/ConstantTime.pm',
     PREREQ_PM         => {
                          },
-    LIBS              => [''],
-    DEFINE            => '',
-    INC               => '-I.',
     OBJECT            => 'ConstantTime.o',
     LICENSE           => 'perl',
     dist => {


### PR DESCRIPTION
This PR bundles a few changes which are related to metadata updates in `Makefile.PL`.

  - the AUTHOR and ABSTRACT entries are helpful for sites like MetaCPAN to display more complete data about the dist
  - I noticed that some variable definitions simply used empty values and hence these could be removed
  - I also noticed that instead of evaluating the value of `$ExtUtils::MakeMaker::VERSION` one could just refer to it directly, hence saving an `eval` and the use of a temporary variable without hurting readability
  - I set the minimum Perl version to 5.8.0.  As mentioned in the commit message, the code actually supports 5.6.0, however since the tests use the `use uft8` pragma, they require at least 5.8.0, thus by setting this value in the metadata, this should help CPAN Testers use the correct Perl version when testing, while at the same time still allowing users to install on 5.6.0 if the so desire.

I've split this PR into separate commits so that you can cherry pick them if you want to.  If you want me to update any of the commits, please just let me know and I'll be happy to fix the commits and resubmit the PR.

I also noticed that it's probably easier to set the minimum `ExtUtils::MakeMaker` version in the `use` statement rather by having extra metadata options specified in an `if` block.  Since even the current version of `ExtUtils::MakeMaker` is supported on Perl 5.6.0, such a change should still be OK and it would remove the need for the `if` block in `Makefile.PL` thus simplifying the code a little bit.  I didn't include such a change in this PR since I wanted to ask you about this first to check if such a change would fit with your coding practices (I don't want to step on any toes!).