### PR TITLE
Purge trailing whitespace

### DIFF
--- a/ConstantTime.xs
+++ b/ConstantTime.xs
@@ -4,7 +4,7 @@
 
 
 
-static int do_compare(unsigned char *a, unsigned char *b, size_t n) {   
+static int do_compare(unsigned char *a, unsigned char *b, size_t n) {
   size_t i;
   unsigned char r = 0;
 
@@ -17,7 +17,7 @@ static int do_compare(unsigned char *a, unsigned char *b, size_t n) {
 
 
 
-MODULE = String::Compare::ConstantTime		PACKAGE = String::Compare::ConstantTime		
+MODULE = String::Compare::ConstantTime		PACKAGE = String::Compare::ConstantTime
 
 PROTOTYPES: ENABLE
 


### PR DESCRIPTION
Trailing whitespace is seen in some projects as bad practice (e.g. the Linux kernel) and is hence explicitly forbidden; other projects see its removal as plain nit-picking. This PR is submitted in the hope that it is helpful, however if you don't see any need to remove such whitespace I'm happy if you close the PR as unmerged.