### PR TITLE
Ignore cover-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ ConstantTime.bs
 ConstantTime.c
 ConstantTime.o
 MANIFEST.bak
+cover_db/
+*.gcov
+*.gcno
+*.gcda


### PR DESCRIPTION
This PR ignores files automatically generated as part of a `cover` run (from `Devel::Cover`).  If you see this change as being unnecessary, I'm OK with it not being merged.  Of course, if it's helpful, merge away!  :-)