### PR TITLE
Add perl shebang to test files

### DIFF
--- a/t/accuracy.t
+++ b/t/accuracy.t
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl
+
 use strict;
 use warnings;
 

--- a/t/magic.t
+++ b/t/magic.t
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl
+
 use strict;
 use warnings;
 

--- a/t/stats.t
+++ b/t/stats.t
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl
+
 use String::Compare::ConstantTime;
 
 use strict;


### PR DESCRIPTION
The shebang (`#!`) not only specifies which interpreter to use for the
files, but also highlights that the files are to be run as scripts, not
loaded as modules would be.  By setting the shebang line the module can
now also conform to `Perl::Critic` severity level 4.