### PR TITLE
Use faster Travis containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 
 language: perl
 


### PR DESCRIPTION
For some reason I left sudo required here.  Since `sudo` isn't used in the Travis config, it can be turned off and hence the faster Travis infrastructure can be used.