### PR TITLE
Include Perls with debugging enabled in Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,28 @@ language: perl
 
 perl:
     - "5.26"
+    - "5.26-dbg"
     - "5.24"
+    - "5.24-dbg"
     - "5.22"
+    - "5.22-dbg"
     - "5.20"
+    - "5.20-dbg"
     - "5.18"
+    - "5.18-dbg"
     - "5.16"
+    - "5.16-dbg"
     - "5.14"
+    - "5.14-dbg"
     - "5.12"
+    - "5.12-dbg"
     - "5.10"
+    - "5.10-dbg"
+    - "5.8"
+    - "5.8-dbg"
+
+before_install:
+      - eval $(curl https://travis-perl.github.io/init) --auto
 
 install:
     - cpanm --installdeps .


### PR DESCRIPTION
By using the travis-perl-helpers one can also test the dist against a
perl built with debugging symbols turned on.  This can help highlight
potential issues which might not turn up when debugging is turned off.

This patch is intended to be used in helping to debug issue #4.  Don't feel that you need to merge it, however I hope it helps in some way to work out what's happening when debugging is enabled in Perl.