### PR TITLE
Replace SvCUR with sv_len_utf8

### DIFF
--- a/ConstantTime.xs
+++ b/ConstantTime.xs
@@ -38,10 +38,10 @@ equals(a, b)
         SvGETMAGIC(b);
 
         if (SvOK(a) && SvOK(b)) {
-          alen = SvCUR(a);
+          alen = sv_len_utf8(a);
           ap = SvPV(a, alen);
 
-          blen = SvCUR(b);
+          blen = sv_len_utf8(b);
           bp = SvPV(b, blen);
 
           if (alen == blen) {


### PR DESCRIPTION
Which should more reliably obtain the string length on Perls with and
without debugging.

This is intended as a fix for issue #4.  I don't expect you to merge it necessarily; however I hope it helps towards solving the underlying problem :-)