### PR TITLE
Improve UTF-8 handling

### DIFF
--- a/ConstantTime.xs
+++ b/ConstantTime.xs
@@ -38,10 +38,7 @@ equals(a, b)
         SvGETMAGIC(b);
 
         if (SvOK(a) && SvOK(b)) {
-          alen = sv_len_utf8(a);
           ap = SvPV(a, alen);
-
-          blen = sv_len_utf8(b);
           bp = SvPV(b, blen);
 
           if (alen == blen) {

--- a/lib/String/Compare/ConstantTime.pm
+++ b/lib/String/Compare/ConstantTime.pm
@@ -53,6 +53,7 @@ This module provides one function, C<equals> (not exported by default).
 
 You should pass this function two strings of the same length. Just like perl's C<eq>, it will return true if they are string-wise identical and false otherwise. However, comparing any two differing strings of the same length will take a fixed amount of time. If the lengths of the strings are different, C<equals> will return false right away.
 
+B<NOTE>: This does byte-wise comparison of the underlying string storage, meaning that comparing strings with non-ASCII data with different states of the internal UTF-8 flag is not reliable.  You should always encode your data to bytes before comparing.
 
 
 =head1 TIMING SIDE-CHANNEL

--- a/t/accuracy.t
+++ b/t/accuracy.t
@@ -8,7 +8,7 @@ use String::Compare::ConstantTime qw/equals/;
 use utf8;
 use Encode;
 
-use Test::More tests => 21;
+use Test::More tests => 26;
 
 
 ok(equals("asdf", "asdf"));
@@ -42,3 +42,14 @@ ok( utf8::is_utf8($string_utf8_on), "utf8 flag on");
 my $string_utf8_off = Encode::encode("utf8", $string_utf8_on);
 ok( !utf8::is_utf8($string_utf8_off), "utf8 flag off");
 ok(equals($string_utf8_on, $string_utf8_off));
+
+my $latin1_e_acute = "\xe9";
+ok( !utf8::is_utf8($latin1_e_acute), "latin-1 e-acute has utf8 flag off");
+my $utf8_e_acute = "é";
+ok( utf8::is_utf8($utf8_e_acute), "UTF-8 e-acute has utf8 flag on");
+ok(!equals($latin1_e_acute, $utf8_e_acute), "latin-1 vs UTF-8 not equal to us");
+ok($latin1_e_acute eq $utf8_e_acute, "but perl thinks they are");
+
+utf8::encode($utf8_e_acute);
+utf8::encode($latin1_e_acute);
+ok(equals($latin1_e_acute, $utf8_e_acute), "after encoding, they are equal to us");


### PR DESCRIPTION
This PR makes two changes:
* Removes the unnecessary sv_len_utf8 that causes warnings on older Perls
* Documents (and tests) issues comparing strings with different UTF-8 flags
